### PR TITLE
Fix CommonJS options

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   },
   build: {
     commonjsOptions: {
-      include: [/pdfjs-dist/]
+      include: [/node_modules/, /pdfjs-dist/]
     },
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary
- update `commonjsOptions.include` to handle `node_modules`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d4134a0c8333ae07ee19b20a00f5